### PR TITLE
remove numpy dependency because there is another way to get bytes dat…

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -2,10 +2,10 @@ FROM debian:testing
 MAINTAINER Danijel Koržinek <danijel.korzinek@pja.edu.pl>
 
 RUN apt-get update && \
-            apt-get install -y python3 python3-pip git libavdevice-dev libavfilter-dev libopus-dev libvpx-dev pkg-config &&\
-            apt-get clean && apt-get autoclean
+    apt-get install -y python3 python3-pip git libavdevice-dev libavfilter-dev libopus-dev libvpx-dev pkg-config &&\
+    apt-get clean && apt-get autoclean
 
-RUN pip3 install aiortc aiohttp numpy
+RUN pip3 install aiortc aiohttp
 
 RUN git clone https://github.com/danijel3/KaldiWebrtcServer /server
 

--- a/kaldi.py
+++ b/kaldi.py
@@ -65,8 +65,7 @@ class KaldiSink:
             try:
                 frame = await self.__track.recv()
                 frame = self.__resampler.resample(frame)
-                data = frame.to_ndarray()
-                self.__kaldi_writer.write(data.tobytes())
+                self.__kaldi_writer.write(frame.planes[0].to_bytes())
                 await self.__kaldi_writer.drain() #without this we won't catch any write exceptions
             except:
                 self.__kaldi_writer.close()


### PR DESCRIPTION
According to aiortc , the MediaStreamTrack recieve AudioFrame object. And the code is convert AudioFrame to bytes data for model.  But converting AudioFrame to bytes data, we used numpy. 

According to this document, 
https://pyav.org/docs/develop/api/audio.html#module-av.audio.frame
<img width="625" alt="Screen Shot 2021-02-21 at 6 24 52 PM" src="https://user-images.githubusercontent.com/12568287/108622198-1e659680-7472-11eb-9c24-f61ccbde75ff.png">
The method to_ndarray is depend on numpy and convert data into numpy object first. Then convert numpy object to bytes data. 

Using this new commit code, 
you can satisfy this goal and without using numpy (save 100MB space)  and more quickly. 

